### PR TITLE
Splits on level entry reset fix

### DIFF
--- a/LiveSplit.SuperMario64.asl
+++ b/LiveSplit.SuperMario64.asl
@@ -76,7 +76,7 @@ split
 			if (splitStarCount == current.Stars && !isKeySplit) //Postpone key split to later
 				vars.split = 1;
 		} 
-		else if (lastSymbol == ']' && old.level != current.level)
+		else if (lastSymbol == ']' && old.level != current.level && old.level != 1)
 		{
 			print("Level trigger!");
 			char[] separators = {'(', ')', '[', ']'};


### PR DESCRIPTION
Fixed the problem where if your first split was a level entry into the start level (like you split on your return to the level you start in; usually via exit course), the autosplitter would split when you enter in the level from file select, resulting in a required 5 second split.